### PR TITLE
Cache requests to static resources

### DIFF
--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
-    <link rel="stylesheet" href="vendor/css/animate.min.css">
-    <link rel="stylesheet" href="vendor/css/material-design-iconic-font.min.css">
+    <link rel="stylesheet" href="vendor/css/animate.min.css?fingerprint={{cache-fingerprint}}">
+    <link rel="stylesheet" href="vendor/css/material-design-iconic-font.min.css?fingerprint={{cache-fingerprint}}">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,600,400italic,600italic,700italic' rel='stylesheet' type='text/css'>
-    <link href="css/compiled/site.css" rel="stylesheet" type="text/css">
+    <link href="css/compiled/site.css?fingerprint={{cache-fingerprint}}" rel="stylesheet" type="text/css">
   </head>
   <body>
     <div id="app"></div>

--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="js/compiled/app.js"></script>
+    <script src="js/compiled/app.js?fingerprint={{cache-fingerprint}}"></script>
     <script>lomake_editori.core.init();</script>
   </body>
 </html>

--- a/spec/lomake_editori/clerk_routes_spec.clj
+++ b/spec/lomake_editori/clerk_routes_spec.clj
@@ -35,7 +35,10 @@
       (should-not-be-nil (re-matches #"(?s).*<script src=\"js/compiled/app.js\?fingerprint=\d{13}\"></script>.*" body))))
 
   (it "should have text/html as content type"
-    (should-have-header "Content-Type" "text/html; charset=utf-8" @resp)))
+    (should-have-header "Content-Type" "text/html; charset=utf-8" @resp))
+
+  (it "should have Cache-Control: no-cache header"
+    (should-have-header "Cache-Control" "no-cache" @resp)))
 
 (describe "Getting a static resource"
   (with-static-resource resp "/lomake-editori/js/compiled/app.js")
@@ -44,6 +47,9 @@
     (should-not-be-nil @resp))
 
   (it "should return HTTP 200"
-    (should= 200 (:status @resp))))
+    (should= 200 (:status @resp)))
+
+  (it "should have Cache-Control: max-age=86400 header"
+    (should-have-header "Cache-Control" "max-age=86400" @resp)))
 
 (run-specs)

--- a/spec/lomake_editori/clerk_routes_spec.clj
+++ b/spec/lomake_editori/clerk_routes_spec.clj
@@ -1,5 +1,6 @@
 (ns lomake-editori.clerk-routes-spec
   (:require [lomake-editori.clerk-routes :as clerk]
+            [lomake-editori.test-utils :refer [should-have-header]]
             [ring.mock.request :as mock]
             [speclj.core :refer :all]))
 
@@ -7,13 +8,6 @@
   [name path]
   `(with ~name (-> (mock/request :get ~path)
                    (clerk/clerk-routes))))
-
-(defn ^:private should-have-header
-  [header expected-val resp]
-  (let [headers (:headers @resp)]
-    (should-not-be-nil headers)
-    (should-contain header headers)
-    (should= expected-val (get headers header))))
 
 (describe "GET /lomake-editori"
   (with-static-resource resp "/lomake-editori")
@@ -25,7 +19,7 @@
     (should= 302 (:status @resp)))
 
   (it "should redirect to /lomake-editori/"
-    (should-have-header "Location" "http://localhost/lomake-editori/" resp)))
+    (should-have-header "Location" "http://localhost/lomake-editori/" @resp)))
 
 (describe "GET /lomake-editori/"
   (with-static-resource resp "/lomake-editori/")
@@ -41,7 +35,7 @@
       (should-not-be-nil (re-matches #"(?s).*<script src=\"js/compiled/app.js\?fingerprint=\d{13}\"></script>.*" body))))
 
   (it "should have text/html as content type"
-    (should-have-header "Content-Type" "text/html; charset=utf-8" resp)))
+    (should-have-header "Content-Type" "text/html; charset=utf-8" @resp)))
 
 (describe "Getting a static resource"
   (with-static-resource resp "/lomake-editori/js/compiled/app.js")

--- a/spec/lomake_editori/clerk_routes_spec.clj
+++ b/spec/lomake_editori/clerk_routes_spec.clj
@@ -38,7 +38,7 @@
 
   (it "should refer to the compiled app.js in response body"
     (let [body (:body @resp)]
-      (should-not-be-nil (re-matches #"(?s).*<script src=\"js/compiled/app.js\"></script>.*" body))))
+      (should-not-be-nil (re-matches #"(?s).*<script src=\"js/compiled/app.js\?fingerprint=\d{13}\"></script>.*" body))))
 
   (it "should have text/html as content type"
     (should-have-header "Content-Type" "text/html; charset=utf-8" resp)))

--- a/spec/lomake_editori/middleware/cache_control_spec.clj
+++ b/spec/lomake_editori/middleware/cache_control_spec.clj
@@ -26,11 +26,3 @@
     (with-resp [resp "/lomake-editori/"]
       (should-not-be-nil resp)
       (should-have-header "Cache-Control" "no-cache" resp))))
-
-
-
-;
-;(it "should not add Cache-Control header for app root without trailing slash"
-;  (with-resp [resp "/lomake-editori"]
-;    (should-not-be-nil resp)
-;    (should-not-have-header "Cache-Control" resp)))

--- a/spec/lomake_editori/middleware/cache_control_spec.clj
+++ b/spec/lomake_editori/middleware/cache_control_spec.clj
@@ -1,0 +1,19 @@
+(ns lomake-editori.middleware.cache-control-spec
+  (:require [lomake-editori.middleware.cache-control :as cache]
+            [ring.util.http-response :as response]
+            [speclj.core :refer :all]))
+
+(defn ^:private stub-handler
+  [_]
+  (response/ok {}))
+
+(describe "cache-control middleware"
+  (it "should add Cache-Control: max-age=86400 header"
+    (let [wrap-fn (cache/wrap-cache-control stub-handler)
+          req     {}
+          resp    (wrap-fn req)]
+      (should-not-be-nil resp)
+      (let [headers (:headers resp)]
+        (should-not-be-nil headers)
+        (should-contain "Cache-Control" headers)
+        (should= "max-age=86400" (get headers "Cache-Control"))))))

--- a/spec/lomake_editori/middleware/cache_control_spec.clj
+++ b/spec/lomake_editori/middleware/cache_control_spec.clj
@@ -1,5 +1,6 @@
 (ns lomake-editori.middleware.cache-control-spec
   (:require [lomake-editori.middleware.cache-control :as cache]
+            [lomake-editori.test-utils :refer [should-have-header should-not-have-header]]
             [ring.mock.request :as mock]
             [ring.util.http-response :as response]
             [speclj.core :refer :all]))
@@ -8,13 +9,28 @@
   [_]
   (response/ok {}))
 
+(defmacro with-resp
+  [binding & body]
+  `(let [wrap-fn# (cache/wrap-cache-control stub-handler)
+         req# (mock/request :get ~(second binding))
+         ~(first binding) (wrap-fn# req#)]
+     ~@body))
+
 (describe "cache-control middleware"
-  (it "should add Cache-Control: max-age=86400 header"
-    (let [wrap-fn (cache/wrap-cache-control stub-handler)
-          req     (mock/request :get "/lomake-editori/static-resource.js")
-          resp    (wrap-fn req)]
+  (it "should add Cache-Control: max-age=86400 header for static resources"
+    (with-resp [resp "/lomake-editori/static-resource.js"]
       (should-not-be-nil resp)
-      (let [headers (:headers resp)]
-        (should-not-be-nil headers)
-        (should-contain "Cache-Control" headers)
-        (should= "max-age=86400" (get headers "Cache-Control"))))))
+      (should-have-header "Cache-Control" "max-age=86400" resp)))
+
+  (it "should add Cache-Control: no-cache header for app root"
+    (with-resp [resp "/lomake-editori/"]
+      (should-not-be-nil resp)
+      (should-have-header "Cache-Control" "no-cache" resp))))
+
+
+
+;
+;(it "should not add Cache-Control header for app root without trailing slash"
+;  (with-resp [resp "/lomake-editori"]
+;    (should-not-be-nil resp)
+;    (should-not-have-header "Cache-Control" resp)))

--- a/spec/lomake_editori/middleware/cache_control_spec.clj
+++ b/spec/lomake_editori/middleware/cache_control_spec.clj
@@ -1,5 +1,6 @@
 (ns lomake-editori.middleware.cache-control-spec
   (:require [lomake-editori.middleware.cache-control :as cache]
+            [ring.mock.request :as mock]
             [ring.util.http-response :as response]
             [speclj.core :refer :all]))
 
@@ -10,7 +11,7 @@
 (describe "cache-control middleware"
   (it "should add Cache-Control: max-age=86400 header"
     (let [wrap-fn (cache/wrap-cache-control stub-handler)
-          req     {}
+          req     (mock/request :get "/lomake-editori/static-resource.js")
           resp    (wrap-fn req)]
       (should-not-be-nil resp)
       (let [headers (:headers resp)]

--- a/spec/lomake_editori/middleware/cache_control_spec.clj
+++ b/spec/lomake_editori/middleware/cache_control_spec.clj
@@ -25,4 +25,9 @@
   (it "should add Cache-Control: no-cache header for app root"
     (with-resp [resp "/lomake-editori/"]
       (should-not-be-nil resp)
-      (should-have-header "Cache-Control" "no-cache" resp))))
+      (should-have-header "Cache-Control" "no-cache" resp)))
+
+  (it "should add Cache-Control: no-store for requests to /lomake-editori/api"
+    (with-resp [resp "/lomake-editori/api/forms"]
+      (should-not-be-nil resp)
+      (should-have-header "Cache-Control" "no-store" resp))))

--- a/spec/lomake_editori/test_utils.clj
+++ b/spec/lomake_editori/test_utils.clj
@@ -1,0 +1,9 @@
+(ns lomake-editori.test-utils
+  (:require [speclj.core :refer :all]))
+
+(defn should-have-header
+  [header expected-val resp]
+  (let [headers (:headers resp)]
+    (should-not-be-nil headers)
+    (should-contain header headers)
+    (should= expected-val (get headers header))))

--- a/spec/lomake_editori/test_utils.clj
+++ b/spec/lomake_editori/test_utils.clj
@@ -7,3 +7,9 @@
     (should-not-be-nil headers)
     (should-contain header headers)
     (should= expected-val (get headers header))))
+
+(defn should-not-have-header
+  [header resp]
+  (let [headers (:headers resp)]
+    (should-not-be-nil headers)
+    (should-not-contain header headers)))

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -44,10 +44,11 @@
       (file-response file {:root "dev-resources"}))))
 
 (defn app-routes []
+  (let [cache-fingerprint (System/currentTimeMillis)]
   (api/api
   (GET "/" [] (redirect "/lomake-editori/"))
   (GET "/lomake-editori" [] (redirect "/lomake-editori/")) ;; Without slash -> 404 unless we do this redirect
-  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {}))))
+  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {:cache-fingerprint cache-fingerprint})))))
 
 (s/defschema Form
   {(s/optional-key :id) (s/maybe s/Str)

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -43,10 +43,11 @@
     (GET "/:file" [file]
       (file-response file {:root "dev-resources"}))))
 
-(defroutes app-routes
+(defn app-routes []
+  (api/api
   (GET "/" [] (redirect "/lomake-editori/"))
   (GET "/lomake-editori" [] (redirect "/lomake-editori/")) ;; Without slash -> 404 unless we do this redirect
-  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {})))
+  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {}))))
 
 (s/defschema Form
   {(s/optional-key :id) (s/maybe s/Str)
@@ -76,7 +77,7 @@
 (def clerk-routes
   (-> (routes (wrap-routes dev-routes wrap-dev-only)
                     resource-routes
-                    app-routes
+                    (app-routes)
                     (api-routes)
                     (route/not-found "Not found"))
       (wrap-defaults (-> site-defaults

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -43,9 +43,9 @@
     (GET "/:file" [file]
       (file-response file {:root "dev-resources"}))))
 
-(defn app-routes []
+(defn get-app-routes []
   (let [cache-fingerprint (System/currentTimeMillis)]
-  (api/api
+  (defroutes app-routes
   (GET "/" [] (redirect "/lomake-editori/"))
   (GET "/lomake-editori" [] (redirect "/lomake-editori/")) ;; Without slash -> 404 unless we do this redirect
   (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {:cache-fingerprint cache-fingerprint})))))
@@ -78,7 +78,7 @@
 (def clerk-routes
   (-> (routes (wrap-routes dev-routes wrap-dev-only)
                     resource-routes
-                    (app-routes)
+                    (get-app-routes)
                     (api-routes)
                     (route/not-found "Not found"))
       (wrap-defaults (-> site-defaults

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -44,12 +44,12 @@
     (GET "/:file" [file]
       (file-response file {:root "dev-resources"}))))
 
-(defn get-app-routes []
-  (let [cache-fingerprint (System/currentTimeMillis)]
-  (defroutes app-routes
+(def ^:private cache-fingerprint (System/currentTimeMillis))
+
+(defroutes app-routes
   (GET "/" [] (redirect "/lomake-editori/"))
   (GET "/lomake-editori" [] (redirect "/lomake-editori/")) ;; Without slash -> 404 unless we do this redirect
-  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {:cache-fingerprint cache-fingerprint})))))
+  (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {:cache-fingerprint cache-fingerprint})))
 
 (s/defschema Form
   {(s/optional-key :id) (s/maybe s/Str)
@@ -79,7 +79,7 @@
 (def clerk-routes
   (-> (routes (wrap-routes dev-routes wrap-dev-only)
                     resource-routes
-                    (get-app-routes)
+                    app-routes
                     (api-routes)
                     (route/not-found "Not found"))
       (wrap-defaults (-> site-defaults

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -11,6 +11,7 @@
             [ring.util.response :refer [file-response resource-response redirect]]
             [ring.util.http-response :refer [ok internal-server-error not-found content-type]]
             [lomake-editori.db.form-store :as form-store]
+            [lomake-editori.middleware.cache-control :as cache-control]
             [ring.util.response :refer [response]]
             [taoensso.timbre :refer [spy error]]
             [selmer.parser :as selmer])
@@ -85,4 +86,5 @@
                          (update-in [:security] dissoc :content-type-options)
                          (update-in [:security] dissoc :anti-forgery)
                          (update-in [:responses] dissoc :content-types)))
-      (wrap-gzip)))
+      (wrap-gzip)
+      (cache-control/wrap-cache-control)))

--- a/src/clj/lomake_editori/middleware/cache_control.clj
+++ b/src/clj/lomake_editori/middleware/cache_control.clj
@@ -4,5 +4,9 @@
 (defn wrap-cache-control
   [handler]
   (fn [req]
-    (let [resp (handler req)]
-      (response/header resp "Cache-Control" "max-age=86400"))))
+    (let [resp (handler req)
+          uri  (:uri req)]
+      (if
+        (some #(= uri %) ["/" "/lomake-editori" "/lomake-editori/"])
+        (response/header resp "Cache-Control" "no-cache")
+        (response/header resp "Cache-Control" "max-age=86400")))))

--- a/src/clj/lomake_editori/middleware/cache_control.clj
+++ b/src/clj/lomake_editori/middleware/cache_control.clj
@@ -4,9 +4,10 @@
 (defn wrap-cache-control
   [handler]
   (fn [req]
-    (let [resp (handler req)
-          uri  (:uri req)]
-      (if
-        (some #(= uri %) ["/" "/lomake-editori" "/lomake-editori/"])
-        (response/header resp "Cache-Control" "no-cache")
-        (response/header resp "Cache-Control" "max-age=86400")))))
+    (let [resp  (handler req)
+          uri   (:uri req)
+          cache (cond
+                  (some #(= uri %) ["/" "/lomake-editori" "/lomake-editori/"]) "no-cache"
+                  (clojure.string/starts-with? uri "/lomake-editori/api") "no-store"
+                  :else "max-age=86400")]
+      (response/header resp "Cache-Control" cache))))

--- a/src/clj/lomake_editori/middleware/cache_control.clj
+++ b/src/clj/lomake_editori/middleware/cache_control.clj
@@ -1,0 +1,8 @@
+(ns lomake-editori.middleware.cache-control
+  (:require [ring.util.response :as response]))
+
+(defn wrap-cache-control
+  [handler]
+  (fn [req]
+    (let [resp (handler req)]
+      (response/header resp "Cache-Control" "max-age=86400"))))


### PR DESCRIPTION
Web browsers should be able to cache requests to all static resources (js and css files, images). Despite this we don't want browsers to cache resources indefinitely. In other words resources should be re-downloaded when needed.

There are 2 sides in this implementation:

1) Each static resource referred by the "index.html" is now tagged with a fingerprint HTTP GET parameter.
2) Server adds Cache-Control: no-cache, no-store or max-age=86400 header to each response, depending on the request type.

* The root page has no-cache.
* API calls have no-store.
* Static resources have max-age=86400.