### PR TITLE
Start using com.stuartsierra/component

### DIFF
--- a/dev/clj/user.clj
+++ b/dev/clj/user.clj
@@ -1,0 +1,2 @@
+(ns user
+  (:require [reloaded.repl :refer [set-init! system init start stop go reset]]))

--- a/dev/clj/user.clj
+++ b/dev/clj/user.clj
@@ -1,2 +1,5 @@
 (ns user
-  (:require [reloaded.repl :refer [set-init! system init start stop go reset]]))
+  (:require [reloaded.repl :refer [set-init! system init start stop go reset]]
+            [lomake-editori.system :refer [new-system]]))
+
+(set-init! #(new-system))

--- a/project.clj
+++ b/project.clj
@@ -138,7 +138,6 @@
                              [refactor-nrepl "2.2.0"]
                              [cider/cider-nrepl "0.12.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                              [lein-cljfmt "0.5.1"]]
-                   :source-paths ["env/dev/clj" "env/dev/cljc"]
                    :resource-paths ["dev-resources"]
                    :env {:dev? true}}
              :uberjar {:aot :all

--- a/project.clj
+++ b/project.clj
@@ -83,12 +83,12 @@
   :less {:source-paths ["resources/less"]
          :target-path  "resources/public/css/compiled"}
 
-  :main lomake-editori.core
+  :main lomake-editori.system
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/cljs"]
                         :figwheel {:on-jsload "lomake-editori.core/mount-root"}
-                        :compiler {:main lomake-editori.core
+                        :compiler {:main lomake-editori.system
                                    :output-to "resources/public/js/compiled/app.js"
                                    :output-dir "resources/public/js/compiled/out"
                                    :asset-path "js/compiled/out"
@@ -106,7 +106,7 @@
 
                        {:id "min"
                         :source-paths ["src/cljs"]
-                        :compiler {:main lomake-editori.core
+                        :compiler {:main lomake-editori.system
                                    :output-to "resources/public/js/compiled/app.js"
                                    :optimizations :advanced
                                    :closure-defines {goog.DEBUG false}

--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
 
                  ;clojure
                  [compojure "1.5.0"]
+                 [com.stuartsierra/component "0.3.1"]
                  [metosin/compojure-api "1.0.1"]
                  [aleph "0.4.1"]
                  [ring "1.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -114,7 +114,8 @@
                                                    :provides ["oph.lib.soresu"]}]}}]}
 
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
-                 :init (set! *print-length* 50)}
+                 :init (set! *print-length* 50)
+                 :init-ns user}
 
   :resource {:resource-paths ["templates"]
              :target-path "resources/public"
@@ -131,6 +132,7 @@
                                   [refactor-nrepl "2.2.0"]
                                   [org.clojure/tools.nrepl "0.2.12"]
                                   [snipsnap "0.1.0" :exclusions [org.clojure/clojure]]
+                                  [reloaded.repl "0.2.1"]
                                   [ring/ring-mock "0.3.0"]
                                   [speclj "3.3.2"]
                                   [speclj-junit "0.0.10"]]
@@ -138,6 +140,7 @@
                              [refactor-nrepl "2.2.0"]
                              [cider/cider-nrepl "0.12.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                              [lein-cljfmt "0.5.1"]]
+                   :source-paths ["dev/clj"]
                    :resource-paths ["dev-resources"]
                    :env {:dev? true}}
              :uberjar {:aot :all

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/cljs"]
                         :figwheel {:on-jsload "lomake-editori.core/mount-root"}
-                        :compiler {:main lomake-editori.system
+                        :compiler {:main lomake-editori.core
                                    :output-to "resources/public/js/compiled/app.js"
                                    :output-dir "resources/public/js/compiled/out"
                                    :asset-path "js/compiled/out"
@@ -106,7 +106,7 @@
 
                        {:id "min"
                         :source-paths ["src/cljs"]
-                        :compiler {:main lomake-editori.system
+                        :compiler {:main lomake-editori.core
                                    :output-to "resources/public/js/compiled/app.js"
                                    :optimizations :advanced
                                    :closure-defines {goog.DEBUG false}

--- a/src/clj/lomake_editori/core.clj
+++ b/src/clj/lomake_editori/core.clj
@@ -11,8 +11,6 @@
             [com.stuartsierra.component :as component])
   (:gen-class))
 
-(def server (atom nil))
-
 (defn start-repl! []
   (when (:dev? env)
     (do
@@ -26,24 +24,6 @@
   (migrations/migrate :db "db.migration"))
 
 (defn- try-f [f] (try (f) (catch Exception ignored nil)))
-
-(defn wait-forever [] @(promise))
-
-(defn -main [& [prt & _]]
-  (let [port (or (try-f (fn [] (Integer/parseInt prt)))
-                 8350)]
-    (do
-      (a/go (start-repl!))
-      (a/go (run-migrations))
-      (info "Starting server on port" port)
-      (reset! server
-              (http/start-server
-               (if (:dev? env)
-                 (wrap-reload (var clerk-routes))
-                 clerk-routes)
-               {:port port}))
-      (info "Started server on port" port)
-      (wait-forever))))
 
 (defrecord Server []
   component/Lifecycle

--- a/src/clj/lomake_editori/core.clj
+++ b/src/clj/lomake_editori/core.clj
@@ -25,7 +25,9 @@
 
   (start [component]
     (let [port    8350
-          handler clerk-routes
+          handler (if (:dev? env)
+                    (wrap-reload (var clerk-routes))
+                    clerk-routes)
           server  (http/start-server handler {:port port})]
       (do
         (a/go (start-repl!)))

--- a/src/clj/lomake_editori/core.clj
+++ b/src/clj/lomake_editori/core.clj
@@ -1,7 +1,6 @@
 (ns lomake-editori.core
   (:require [taoensso.timbre :refer [info]]
             [lomake-editori.clerk-routes :refer [clerk-routes]]
-            [lomake-editori.db.migrations :as migrations]
             [clojure.core.async :as a]
             [environ.core :refer [env]]
             [ring.middleware.reload :refer [wrap-reload]]
@@ -17,12 +16,6 @@
       (start-server :port 3333 :handler cider-nrepl-handler)
       (info "nREPL started on port 3333"))))
 
-(defn run-migrations []
-  ;; Only run migrations when in dev mode for now
-  ;; Deployment has to catch up before we can run migrations on test/prod
-  ;; servers
-  (migrations/migrate :db "db.migration"))
-
 (defmacro ^:private try-f
   [& form]
   `(try ~@form (catch Exception _#)))
@@ -35,8 +28,7 @@
           handler clerk-routes
           server  (http/start-server handler {:port port})]
       (do
-        (a/go (start-repl!))
-        (a/go (run-migrations)))
+        (a/go (start-repl!)))
       (info (str "Started server on port " port))
       (assoc component :server server)))
 

--- a/src/clj/lomake_editori/core.clj
+++ b/src/clj/lomake_editori/core.clj
@@ -23,7 +23,9 @@
   ;; servers
   (migrations/migrate :db "db.migration"))
 
-(defn- try-f [f] (try (f) (catch Exception ignored nil)))
+(defmacro ^:private try-f
+  [& form]
+  `(try ~@form (catch Exception _#)))
 
 (defrecord Server []
   component/Lifecycle

--- a/src/clj/lomake_editori/db/migrations.clj
+++ b/src/clj/lomake_editori/db/migrations.clj
@@ -1,6 +1,21 @@
 (ns lomake-editori.db.migrations
-  (:require [oph.soresu.common.db.migrations :as migrations])
+  (:require [com.stuartsierra.component :as component]
+            [oph.soresu.common.db.migrations :as migrations])
   (:use [oph.soresu.common.config :only [config]]))
 
-(defn migrate [ds-key & migration-paths]
+(defn ^:private migrate [ds-key & migration-paths]
   (apply (partial migrations/migrate ds-key) migration-paths))
+
+(defrecord Migration []
+  component/Lifecycle
+
+  (start [component]
+    (migrations/migrate :db "db.migration")
+    component)
+
+  (stop [component]
+    component))
+
+(defn new-migration
+  []
+  (->Migration))

--- a/src/clj/lomake_editori/system.clj
+++ b/src/clj/lomake_editori/system.clj
@@ -1,9 +1,19 @@
 (ns lomake-editori.system
   (:require [com.stuartsierra.component :as component]
-            [lomake-editori.core :as server]))
+            [lomake-editori.core :as server]
+            [taoensso.timbre :refer [info]]))
 
 (defn new-system
   []
   (component/system-map
     :server (server/new-server)))
 
+(defn ^:private wait-forever
+  []
+  @(promise))
+
+(defn -main [& _]
+  (let [system (new-system)]
+    (info "Starting lomake-editori system")
+    (component/start-system system)
+    (wait-forever)))

--- a/src/clj/lomake_editori/system.clj
+++ b/src/clj/lomake_editori/system.clj
@@ -1,0 +1,6 @@
+(ns lomake-editori.system
+  (:require [com.stuartsierra.component :as component]))
+
+(defn new-system
+  []
+  (component/system-map))

--- a/src/clj/lomake_editori/system.clj
+++ b/src/clj/lomake_editori/system.clj
@@ -1,6 +1,9 @@
 (ns lomake-editori.system
-  (:require [com.stuartsierra.component :as component]))
+  (:require [com.stuartsierra.component :as component]
+            [lomake-editori.core :as server]))
 
 (defn new-system
   []
-  (component/system-map))
+  (component/system-map
+    :server (server/new-server)))
+

--- a/src/clj/lomake_editori/system.clj
+++ b/src/clj/lomake_editori/system.clj
@@ -15,5 +15,5 @@
 (defn -main [& _]
   (let [system (new-system)]
     (info "Starting lomake-editori system")
-    (component/start-system system)
-    (wait-forever)))
+    (let [_ (component/start-system system)]
+      (wait-forever))))

--- a/src/clj/lomake_editori/system.clj
+++ b/src/clj/lomake_editori/system.clj
@@ -1,12 +1,14 @@
 (ns lomake-editori.system
   (:require [com.stuartsierra.component :as component]
             [lomake-editori.core :as server]
+            [lomake-editori.db.migrations :as migrations]
             [taoensso.timbre :refer [info]]))
 
 (defn new-system
   []
   (component/system-map
-    :server (server/new-server)))
+    :migration (migrations/new-migration)
+    :server    (server/new-server)))
 
 (defn ^:private wait-forever
   []


### PR DESCRIPTION
The REPL now uses reloaded.repl based workflow, so the server can be started from REPL with (reset), (start) and stopped with (stop).

Due to some technical difficulties (probably in the cljs side) the auto-reloading by Figwheel (when componentified) doesn't work. So this feature doesn't include that. So in practice one'll need to run the Figwheel Java side separately from terminal.