### PR TITLE
Capability to run UI tests in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /*-init.clj
 /resources/public/js/compiled
+/resources/public/js/test
 out
 .lein-env
 .lein-failures

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 .cljs_rhino_repl
 .DS_Store
 resources/public/buildversion.txt
+config/docker.edn

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ lein with-profile dev run
 lein figwheel dev
 
 # And in the third window, run cljsbuild for tests to automatically recompile test.js
-lein cljdbuild auto test
+lein cljsbuild auto test
 ```
 
 After this you can run tests by navigating to http://localhost:8350/lomake-editori/test.html .

--- a/README.md
+++ b/README.md
@@ -71,20 +71,34 @@ lein with-profile dev figwheel dev
 
 Browse to [http://localhost:3450](http://localhost:3450).
 
-### Run tests:
+### Browser tests:
 
-[doo](https://github.com/bensu/doo) assumes that [PhantomJS](http://phantomjs.org/) is installed locally to `./node_modules/phantomjs-prebuilt/bin/phantomjs`. The `package.json` in this repository does just that:
+Browser tests can be run by invoking
 
 ```
 npm install
+
+# In one terminal window, run the actual application:
+lein with-profile dev run
+
+# In second window, you'll want to run figwheel in dev profile as normally:
+lein figwheel dev
+
+# And in the third window, run cljsbuild for tests to automatically recompile test.js
+lein cljdbuild auto test
 ```
 
-To actually run tests:
+After this you can run tests by navigating to http://localhost:8350/lomake-editori/test.html .
+
+### Backend tests
+
+To run tests once:
 
 ```
-lein clean
-lein doo phantom test once
+lein spec
 ```
+
+To run them automatically whenever code changes, use `-a`.
 
 ### Clojure linter
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   },
   "license": "EUPL-1.1",
   "devDependencies": {
+    "karma": "^0.13.22",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-cljs-test": "^0.1.0",
+    "karma-safari-launcher": "^0.1.1",
     "phantomjs-prebuilt": "*"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,6 @@
 
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-figwheel "0.5.0-6"]
-            [lein-doo "0.1.6"]
             [lein-less "1.7.5"]
             [lein-ancient "0.6.8"]
             [lein-environ "1.0.2"]
@@ -80,9 +79,6 @@
 
   :figwheel {:css-dirs ["resources/public/css"]
              :nrepl-port 3334}
-
-  :doo {:paths {:phantom "./node_modules/phantomjs-prebuilt/bin/phantomjs"
-                :karma "./node_modules/karma/bin/karma"}}
 
   :less {:source-paths ["resources/less"]
          :target-path  "resources/public/css/compiled"}

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,9 @@
                  ;clojure/clojurescript
                  [prismatic/schema "1.0.5"]
                  [com.taoensso/timbre "4.3.1"]
+                 [org.clojure/core.async "0.2.374"]
                  [org.clojure/core.match "0.3.0-alpha4"]
+                 [jayq "2.5.4"]
 
                  ;clojure
                  [compojure "1.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -73,12 +73,14 @@
              :exclude-linters [:local-shadows-var]}
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
-                                    "test/js"]
+                                    "test/js"
+                                    "resources/public/js/test"]
 
   :figwheel {:css-dirs ["resources/public/css"]
              :nrepl-port 3334}
 
-  :doo {:paths {:phantom "./node_modules/phantomjs-prebuilt/bin/phantomjs"}}
+  :doo {:paths {:phantom "./node_modules/phantomjs-prebuilt/bin/phantomjs"
+                :karma "./node_modules/karma/bin/karma"}}
 
   :less {:source-paths ["resources/less"]
          :target-path  "resources/public/css/compiled"}
@@ -98,7 +100,9 @@
 
                        {:id "test"
                         :source-paths ["src/cljs" "test/cljs"]
-                        :compiler {:output-to "resources/public/js/compiled/test.js"
+                        :compiler {:output-to "resources/public/js/test/test.js"
+                                   :output-dir "resources/public/js/test/out"
+                                   :asset-path "js/test/out"
                                    :main lomake-editori.runner
                                    :foreign-libs [{:file ~soresu
                                                    :provides ["oph.lib.soresu"]}]

--- a/resources/templates/test.html
+++ b/resources/templates/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8"/>
+    <title>UI tests</title>
+</head>
+<body>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/jquery.xpath/0.2.5/jquery.xpath.min.js"></script>
+<script src="/lomake-editori/js/test/test.js"></script>
+<iframe id="test"></iframe>
+<script>
+    lomake_editori.runner.run()
+</script>
+</body>
+</html>

--- a/src/clj/lomake_editori/clerk_routes.clj
+++ b/src/clj/lomake_editori/clerk_routes.clj
@@ -51,6 +51,12 @@
   (GET "/lomake-editori" [] (redirect "/lomake-editori/")) ;; Without slash -> 404 unless we do this redirect
   (GET "/lomake-editori/" [] (selmer/render-file "templates/index.html" {:cache-fingerprint cache-fingerprint})))
 
+(defroutes test-routes
+  (GET "/lomake-editori/test.html" []
+    (if (:dev? env)
+        (selmer/render-file "templates/test.html" {})
+        (not-found "Not found"))))
+
 (s/defschema Form
   {(s/optional-key :id) (s/maybe s/Int)
    :name s/Str
@@ -80,6 +86,7 @@
   (-> (routes (wrap-routes dev-routes wrap-dev-only)
                     resource-routes
                     app-routes
+                    test-routes
                     (api-routes)
                     (route/not-found "Not found"))
       (wrap-defaults (-> site-defaults

--- a/test/cljs/lomake_editori/core_test.cljs
+++ b/test/cljs/lomake_editori/core_test.cljs
@@ -26,17 +26,21 @@
   [x]
   (not (nil? x)))
 
+(defn get-element
+  [xpath]
+  (let [elements (-> (app-frame)
+                     (.xpath xpath))]
+    (when (= 1 (count elements))
+      (first elements))))
+
 (defn editor-link
-  [app-frame]
-  (let [links (.xpath app-frame "//span[@class='active-section']/span[text()='Lomake-editori']")]
-    (when (= 1 (count links))
-      (first links))))
+  []
+  (get-element "//span[@class='active-section']/span[text()='Lomake-editori']"))
 
 (use-fixtures :once {:before setup})
 
 (deftest ui-header
   (testing "header has editor link"
-    (let [header-link-set? (-> (app-frame)
-                               (editor-link)
+    (let [header-link-set? (-> (editor-link)
                                (not-nil?))]
       (is header-link-set?))))

--- a/test/cljs/lomake_editori/core_test.cljs
+++ b/test/cljs/lomake_editori/core_test.cljs
@@ -1,7 +1,37 @@
 (ns lomake-editori.core-test
-  (:require [cljs.test :refer-macros [deftest testing is]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [goog.dom :as dom]
+            [goog.dom.DomHelper :as dh]
+            [jayq.core :as jq]
             [lomake-editori.core :as core]))
 
-(deftest fake-test
-  (testing "fake description"
-    (is (= 1 1))))
+(defn app-frame
+  []
+  (-> (jq/$ :#test)
+      (first)
+      (.-contentWindow)
+      (.-document)
+      (jq/$)))
+
+(defn setup
+  []
+  (async done
+    (doto (jq/$ :#test)
+      (jq/attr :src "/lomake-editori/")
+      (jq/attr :width "1024")
+      (jq/attr :height "768"))
+    (js/setTimeout done 3000)))
+
+(defn editor-link
+  [app-frame]
+  (.xpath app-frame "//span[@class='active-section']/span[text()='Lomake-editori']"))
+
+(use-fixtures :once {:before setup})
+
+(deftest ui-header
+  (testing "header has editor link"
+    (let [header-link-set? (-> (app-frame)
+                               (editor-link)
+                               (count)
+                               (= 1))]
+      (is header-link-set?))))

--- a/test/cljs/lomake_editori/core_test.cljs
+++ b/test/cljs/lomake_editori/core_test.cljs
@@ -24,7 +24,9 @@
 
 (defn editor-link
   [app-frame]
-  (.xpath app-frame "//span[@class='active-section']/span[text()='Lomake-editori']"))
+  (let [links (.xpath app-frame "//span[@class='active-section']/span[text()='Lomake-editori']")]
+    (when (= 1 (count links))
+      (first links))))
 
 (use-fixtures :once {:before setup})
 
@@ -32,6 +34,6 @@
   (testing "header has editor link"
     (let [header-link-set? (-> (app-frame)
                                (editor-link)
-                               (count)
-                               (= 1))]
+                               (nil?)
+                               (not))]
       (is header-link-set?))))

--- a/test/cljs/lomake_editori/core_test.cljs
+++ b/test/cljs/lomake_editori/core_test.cljs
@@ -22,6 +22,10 @@
       (jq/attr :height "768"))
     (js/setTimeout done 3000)))
 
+(defn not-nil?
+  [x]
+  (not (nil? x)))
+
 (defn editor-link
   [app-frame]
   (let [links (.xpath app-frame "//span[@class='active-section']/span[text()='Lomake-editori']")]
@@ -34,6 +38,5 @@
   (testing "header has editor link"
     (let [header-link-set? (-> (app-frame)
                                (editor-link)
-                               (nil?)
-                               (not))]
+                               (not-nil?))]
       (is header-link-set?))))

--- a/test/cljs/lomake_editori/runner.cljs
+++ b/test/cljs/lomake_editori/runner.cljs
@@ -1,5 +1,7 @@
 (ns lomake-editori.runner
-    (:require [doo.runner :refer-macros [doo-tests]]
+    (:require [cljs.test :refer-macros [run-all-tests]]
               [lomake-editori.core-test]))
 
-(doo-tests 'lomake-editori.core-test)
+(defn ^:export run
+  []
+  (run-all-tests #"lomake-editori.*-test"))


### PR DESCRIPTION
This pull request adds capability to run UI tests. The solution is quite traditional setup where a browser first gets a "test.html" that acts as a runner page. The html page then bootstraps cljs.test based test suite and runs it inside an iframe.